### PR TITLE
Update README.md with info for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Files are also created for Clojure code.  You can check these with:
 
     lein spec
 
+### Note for Windows users:
+
+In order to use specljs on Windows, it is recommended to install PhantomJS through chocolatey:
+
+    choco install phantomjs
+    
+Change the following lines in `bin/speclj`:
+
+* Line 8: `fs.write("/dev/stdout", x, "w");` to `fs.write("\\\\.\\CON", x, "w");`
+* Line 11: `p.injectJs(phantom.args[0]);` to `p.injectJs(sys.args[1]);`
+
+
 ## License
 
 Copyright © 2013 Connor Mendenhall, 2014 Micah Martin


### PR DESCRIPTION
By default, when you create a new project with this template on windows and you run `lein cljsbuild once dev` as suggested in the README, there was no output.

I found the solution for this and I thought it would be better if Windows users could know about this issue and how to solve it.
