### PR TITLE
fix phantom issue

### DIFF
--- a/src/leiningen/new/specljs/speclj
+++ b/src/leiningen/new/specljs/speclj
@@ -8,7 +8,7 @@ p.onConsoleMessage = function (x) {
     fs.write("/dev/stdout", x, "w");
 };
 
-p.injectJs(phantom.args[0]);
+p.injectJs(sys.args[1]);
 
 var result = p.evaluate(function () {
   speclj.run.standard.armed = true;


### PR DESCRIPTION
to avoid the following exception

```
TypeError: undefined is not an object (evaluating 'phantom.args[0]')

  bin/speclj:11 in global code
```

 when `lein cljsbuild test` with phantomjs 2.0.0 installed.

references [phantom/property/args](http://phantomjs.org/api/phantom/property/args.html)
